### PR TITLE
Update PerfCounterReporter solution so that it now uses the latest

### DIFF
--- a/PerfCounterReporter/PerfCounterReporter.csproj
+++ b/PerfCounterReporter/PerfCounterReporter.csproj
@@ -126,7 +126,7 @@
       <HintPath>..\packages\Metrics.NET.0.2.16\lib\net45\Metrics.dll</HintPath>
     </Reference>
     <Reference Include="Metrics.NET.SignalFX">
-      <HintPath>..\packages\Metrics.NET.SignalFX.0.0.3.2\lib\net45\Metrics.NET.SignalFX.dll</HintPath>
+      <HintPath>..\packages\Metrics.NET.SignalFX.2.2.0.0\lib\net45\Metrics.NET.SignalFX.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/PerfCounterReporter/PerfCounterReporterService.cs
+++ b/PerfCounterReporter/PerfCounterReporterService.cs
@@ -22,7 +22,7 @@ namespace PerfCounterReporter
             
 
             _log.Info("Reading signalFx reporter config");
-            Tuple<MetricsReport, TimeSpan> reporter = SignalFxReporterBuilder.FromAppConfig().Build();
+            Tuple<MetricsReport, TimeSpan> reporter = SignalFxReporterBuilder.FromAppConfig();
             SyntheticCountersReporter synCR = SyntheticCountersReporter.createDefaultReporter(_log, CounterSamplingConfiguration.FromConfig());
             _pcr = new PerfCounterReporter(reporter.Item1, reporter.Item2, CounterSamplingConfiguration.FromConfig());
             if (synCR != null)

--- a/PerfCounterReporter/packages.config
+++ b/PerfCounterReporter/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Metrics.NET" version="0.2.16" targetFramework="net45" />
-  <package id="Metrics.NET.SignalFX" version="0.0.3.2" targetFramework="net45" />
+  <package id="Metrics.NET.SignalFX" version="2.2.0.0" targetFramework="net45" />
   <package id="NLog" version="4.1.2" targetFramework="net45" />
   <package id="NLog.Config" version="4.1.2" targetFramework="net45" />
   <package id="NLog.Schema" version="4.1.0" targetFramework="net45" />


### PR DESCRIPTION
Metrics.NET.SignalFx.dll which contains an altered FromAppConfig() method signature