### PR TITLE
Various dependency updates

### DIFF
--- a/PerfCounterReporter/PerfCounterReporter.csproj
+++ b/PerfCounterReporter/PerfCounterReporter.csproj
@@ -126,7 +126,7 @@
       <HintPath>..\packages\Metrics.NET.0.2.16\lib\net45\Metrics.dll</HintPath>
     </Reference>
     <Reference Include="Metrics.NET.SignalFX">
-      <HintPath>..\packages\Metrics.NET.SignalFX.2.2.0.0\lib\net45\Metrics.NET.SignalFX.dll</HintPath>
+      <HintPath>..\packages\Metrics.NET.SignalFX.2.2.1.0\lib\net45\Metrics.NET.SignalFX.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/PerfCounterReporter/packages.config
+++ b/PerfCounterReporter/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Metrics.NET" version="0.2.16" targetFramework="net45" />
-  <package id="Metrics.NET.SignalFX" version="2.2.0.0" targetFramework="net45" />
+  <package id="Metrics.NET.SignalFX" version="2.2.1.0" targetFramework="net45" />
   <package id="NLog" version="4.1.2" targetFramework="net45" />
   <package id="NLog.Config" version="4.1.2" targetFramework="net45" />
   <package id="NLog.Schema" version="4.1.0" targetFramework="net45" />
-  <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Updated dependencies to use the new Metrics.NET.SignalFx 2.2.1.0 which has a fix for backward compatibility when no source dimension is specified. Also updated the targetFramework for protobuf-net to reflect what is actually available (4.0, not 4.5)