### PR TITLE
Update various PerfCounterReporter things to improve OOTB usability

### DIFF
--- a/PerfCounterReporter/App.config
+++ b/PerfCounterReporter/App.config
@@ -4,7 +4,7 @@
     <section name="signalFxReporter" type=" Metrics.SignalFx.Configuration.SignalFxReporterConfiguration, Metrics.NET.SignalFx"/>
     <section name="counterSampling" type="PerfCounterReporter.Configuration.CounterSamplingConfiguration, PerfCounterReporter" />
   </configSections>
-  <signalFxReporter apiToken="" sampleInterval="00:00:05" sourceType="netbios" awsIntegration="false"/>
+  <signalFxReporter apiToken="" sampleInterval="00:00:05" sourceType="netbios" sourceDimension="host" awsIntegration="false"/>
   <counterSampling>
     <definitionFilePaths>
       <definitionFile path="CounterDefinitions\\system.counters" />

--- a/PerfCounterReporter/PerfCounterReporter.csproj
+++ b/PerfCounterReporter/PerfCounterReporter.csproj
@@ -126,7 +126,7 @@
       <HintPath>..\packages\Metrics.NET.0.2.16\lib\net45\Metrics.dll</HintPath>
     </Reference>
     <Reference Include="Metrics.NET.SignalFX">
-      <HintPath>..\packages\Metrics.NET.SignalFX.2.2.2.0\lib\net45\Metrics.NET.SignalFX.dll</HintPath>
+      <HintPath>..\packages\Metrics.NET.SignalFX.2.4.2\lib\net45\Metrics.NET.SignalFX.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -211,7 +211,9 @@
     <None Include="NLog.xsd">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Interop\ErrorMessages.resx">

--- a/PerfCounterReporter/packages.config
+++ b/PerfCounterReporter/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Metrics.NET" version="0.2.16" targetFramework="net45" />
-  <package id="Metrics.NET.SignalFX" version="2.2.2.0" targetFramework="net45" />
+  <package id="Metrics.NET.SignalFX" version="2.4.2.0" targetFramework="net45" />
   <package id="NLog" version="4.1.2" targetFramework="net45" />
   <package id="NLog.Config" version="4.1.2" targetFramework="net45" />
   <package id="NLog.Schema" version="4.1.0" targetFramework="net45" />


### PR DESCRIPTION
Update default configuration of PCR to specify a sourceDimension for PCR
metrics of "host" instead of utilizing the current default of
"sf_source" that exists within the Metrics.NET.SignalFx shared library.
This will make us consistent with host metrics from other platforms and
will enable Windows hosts to appear in the host list within SignalFx.

Refresh package to pick up a more comprehensive set of IIS performance
counters and to also pick up the latest and greatest
Metrics.NET.SignalFx.dll.

Make minor updates to the Visual Studio .csproj file to include accurate pathing and fully-qualified dependencies. This removes some unnecessary warnings at build time.