### PR TITLE
Update version property for new PCR Installer

### DIFF
--- a/Installer/Product.wxs
+++ b/Installer/Product.wxs
@@ -11,7 +11,7 @@ after re-generating add:
   <Product Id="b950aa29-c95e-4abb-82f5-37e52bbfa653" 
            Name="PerfCounterReporter" 
            Language="1033"            
-           Version="1.5.0.0" 
+           Version="1.5.1.0" 
            Manufacturer="SignalFx" 
            UpgradeCode="f25124eb-0654-4fe5-b5c9-2d1b8e1b8815">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" InstallPrivileges="elevated" AdminImage="yes" />


### PR DESCRIPTION
Update the version info for the PCR installer from 1.5.0 to 1.5.1 for
the upcoming rebuild