### PR TITLE
Update PCR from 32-bit to 64-bit

### DIFF
--- a/Installer/Installer.wixproj
+++ b/Installer/Installer.wixproj
@@ -70,6 +70,17 @@
   <PropertyGroup>
     <PostBuildEvent />
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <DefineConstants>Debug</DefineConstants>
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <DefineConstants />
+    <WixVariables />
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
   <!--
 	To modify your build process, add your task inside one of the targets below and uncomment it.
 	Other similar extension points exist, see Wix.targets.

--- a/PerfCounterReporter.sln
+++ b/PerfCounterReporter.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerfCounterReporter", "PerfCounterReporter\PerfCounterReporter.csproj", "{A2044707-5BB7-4BE6-8758-362B7B3AB5A9}"
 EndProject
@@ -51,8 +51,8 @@ Global
 		{A2044707-5BB7-4BE6-8758-362B7B3AB5A9}.Release|x86.ActiveCfg = Release|Any CPU
 		{A2044707-5BB7-4BE6-8758-362B7B3AB5A9}.Release-64|Any CPU.ActiveCfg = Release|x64
 		{A2044707-5BB7-4BE6-8758-362B7B3AB5A9}.Release-64|Any CPU.Build.0 = Release|x64
-		{A2044707-5BB7-4BE6-8758-362B7B3AB5A9}.Release-64|Mixed Platforms.ActiveCfg = Release-64|Any CPU
-		{A2044707-5BB7-4BE6-8758-362B7B3AB5A9}.Release-64|Mixed Platforms.Build.0 = Release-64|Any CPU
+		{A2044707-5BB7-4BE6-8758-362B7B3AB5A9}.Release-64|Mixed Platforms.ActiveCfg = Release-64|x64
+		{A2044707-5BB7-4BE6-8758-362B7B3AB5A9}.Release-64|Mixed Platforms.Build.0 = Release-64|x64
 		{A2044707-5BB7-4BE6-8758-362B7B3AB5A9}.Release-64|x64.ActiveCfg = Release|Any CPU
 		{A2044707-5BB7-4BE6-8758-362B7B3AB5A9}.Release-64|x64.Build.0 = Release|Any CPU
 		{A2044707-5BB7-4BE6-8758-362B7B3AB5A9}.Release-64|x86.ActiveCfg = Release-64|Any CPU
@@ -72,8 +72,8 @@ Global
 		{0385EB72-B6E9-45CD-B037-4A548C440E7F}.Release|x86.ActiveCfg = Release|Any CPU
 		{0385EB72-B6E9-45CD-B037-4A548C440E7F}.Release-64|Any CPU.ActiveCfg = Release|x64
 		{0385EB72-B6E9-45CD-B037-4A548C440E7F}.Release-64|Any CPU.Build.0 = Release|x64
-		{0385EB72-B6E9-45CD-B037-4A548C440E7F}.Release-64|Mixed Platforms.ActiveCfg = Release-64|Any CPU
-		{0385EB72-B6E9-45CD-B037-4A548C440E7F}.Release-64|Mixed Platforms.Build.0 = Release-64|Any CPU
+		{0385EB72-B6E9-45CD-B037-4A548C440E7F}.Release-64|Mixed Platforms.ActiveCfg = Release-64|x64
+		{0385EB72-B6E9-45CD-B037-4A548C440E7F}.Release-64|Mixed Platforms.Build.0 = Release-64|x64
 		{0385EB72-B6E9-45CD-B037-4A548C440E7F}.Release-64|x64.ActiveCfg = Release-64|Any CPU
 		{0385EB72-B6E9-45CD-B037-4A548C440E7F}.Release-64|x64.Build.0 = Release-64|Any CPU
 		{0385EB72-B6E9-45CD-B037-4A548C440E7F}.Release-64|x86.ActiveCfg = Release-64|Any CPU
@@ -110,8 +110,8 @@ Global
 		{65072E9B-92AD-442E-AE54-1104FA517B7D}.Release|x86.ActiveCfg = Release|Any CPU
 		{65072E9B-92AD-442E-AE54-1104FA517B7D}.Release-64|Any CPU.ActiveCfg = Release|Any CPU
 		{65072E9B-92AD-442E-AE54-1104FA517B7D}.Release-64|Any CPU.Build.0 = Release|Any CPU
-		{65072E9B-92AD-442E-AE54-1104FA517B7D}.Release-64|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{65072E9B-92AD-442E-AE54-1104FA517B7D}.Release-64|Mixed Platforms.Build.0 = Release|Any CPU
+		{65072E9B-92AD-442E-AE54-1104FA517B7D}.Release-64|Mixed Platforms.ActiveCfg = Release|x64
+		{65072E9B-92AD-442E-AE54-1104FA517B7D}.Release-64|Mixed Platforms.Build.0 = Release|x64
 		{65072E9B-92AD-442E-AE54-1104FA517B7D}.Release-64|x64.ActiveCfg = Release|Any CPU
 		{65072E9B-92AD-442E-AE54-1104FA517B7D}.Release-64|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This code is based on/inspired by PerfTap (https://github.com/Iristyle/PerfTap) 
 * Administrator rights for installing services (the service is installed to run as LOCAL SERVICE)
 
 ### Installation and Configuration Steps
-Download the latest release of the .MSI from the [PerfCounterReporter Releases Page](https://github.com/signalfx/PerfCounterReporter/releases).
+Download the latest release of the .MSI from the [PerfCounterReporter Releases Page](https://github.com/signalfx/PerfCounterReporter/releases). (**NOTE:** As of the 1.6 release, PerfCounterReporter is only being provided as a 64-bit executable. If for some reason you require a 32-bit version of PerfCounterReporter you should use the 1.5.2 release).
 
 Launch the .MSI via your preferred invocation method.
 

--- a/patcher/patcher.csproj
+++ b/patcher/patcher.csproj
@@ -31,6 +31,26 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Update PCR from 32-bit to 64-bit so that it can retrieve counters from 64-bit
services that do not redundantly publish counters that can be accessed by both 32
and 64 bit applications