### PR TITLE
Add additional useful system performance counters

### DIFF
--- a/PerfCounterReporter/CounterDefinitions/system.counters
+++ b/PerfCounterReporter/CounterDefinitions/system.counters
@@ -128,7 +128,7 @@
 
 # Measuring the number of packet errors is an important factor in network health. If
 # there is a large spike in network errors, it usually means that your network is not
-# performing a peak health and needs further exploration. A small number of errors
+# performing at peak health and needs further exploration. A small number of errors
 # is usually exceptable.
 \Network Interface(*)\Packets Received Errors
 \Network Interface(*)\Packets Outbound Errors

--- a/PerfCounterReporter/CounterDefinitions/system.counters
+++ b/PerfCounterReporter/CounterDefinitions/system.counters
@@ -79,6 +79,20 @@
 #of each read to disk where > 20 is poor, <20 is good/fair, <12 is better, <8 is best
 #\PhysicalDisk(_Total)\Avg. Disk sec/Read
 \PhysicalDisk(*)\Avg. Disk sec/Read
+\PhysicalDisk(*)\Avg. Disk sec/Transfer
+
+# Measuring the disk bytes/sec is important to track performance over time. This is
+# especially useful for any data-hosting systems, such as a database.
+\LogicalDisk(*)\Disk Read Bytes/sec
+\LogicalDisk(*)\Disk Write Bytes/sec
+
+# Measuring the disk IOPS is important for any scalable systems, since the disk can
+# only handle so many operations at once. This can eventually lead to a slow-down in
+# performance due to disk operation queuing. Monitoring IOPS is important for any
+# data-hosting system, such as a database or website.
+\LogicalDisk(*)\Disk Transfers/sec
+\LogicalDisk(*)\Disk Reads/sec
+\LogicalDisk(*)\Disk Writes/sec
 
 #The number of bytes sent and received over a specific network adapter, including
 # framing characters. Be sure to record the throughput of your SQL Server's NIC 
@@ -105,6 +119,27 @@
 # bandwidth or for those where no accurate estimation can be made, this value 
 # is the nominal bandwidth.
 \Network Interface(*)\Current Bandwidth
+
+# Tracking the packets received over time can give you a good indication of the
+# typical use of the system's network. A sudden spike or drop in network packets
+# may be worth investigating further.
+\Network Interface(*)\Packets Received/sec
+\Network Interface(*)\Packets Sent/sec
+
+# Measuring the number of packet errors is an important factor in network health. If
+# there is a large spike in network errors, it usually means that your network is not
+# performing a peak health and needs further exploration. A small number of errors
+# is usually exceptable.
+\Network Interface(*)\Packets Received Errors
+\Network Interface(*)\Packets Outbound Errors
+
+# Keeping track of dropped/discarded packets is an important indicator of overall
+# network health. If there is a sudden spike in dropped packets, this is usually
+# an indicator of a network misconfiguration, network traffic overload, network
+# traffic congsestion, or a potential issue with the network device or driver. A small
+# number of dropped packets is usually acceptable.
+\Network Interface(*)\Packets Received Discarded
+\Network Interface(*)\Packets Outbound Discarded
 
 \LogicalDisk(*)\Free Megabytes
 \LogicalDisk(*)\% Free Space


### PR DESCRIPTION
Add additional network and physical/logical disk counters that are
available as a part of PerfCounterReporter's default configuration.